### PR TITLE
X509 Cert Checks

### DIFF
--- a/skaha/client.py
+++ b/skaha/client.py
@@ -239,8 +239,10 @@ class SkahaClient(BaseModel):
             certdata = certfile.read()
         cert = x509.load_pem_x509_certificate(certdata, default_backend())
         now = datetime.now(timezone.utc)
-        assert cert.not_valid_after_utc > now, "SSL certificate expired."
-        assert cert.not_valid_before_utc < now, "SSL certificate not valid yet."
+        if cert.not_valid_after_utc <= now:
+            raise ValueError("SSL certificate expired.")
+        if cert.not_valid_before_utc >= now:
+            raise ValueError("SSL certificate not valid yet.")
         ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         ctx.load_cert_chain(certfile=self.certificate)

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ wheels = [
 
 [[package]]
 name = "skaha"
-version = "1.6.0"
+version = "1.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
* [`skaha/client.py`](diffhunk://#diff-bf9b205f0ef1ed16fb6e60353b148cf6ae1f0b677c009203f46498060c7ee0e3R238-R243): Added logic to validate SSL certificate expiration (`not_valid_after_utc`) and activation (`not_valid_before_utc`) using the `cryptography` library within the `_get_cert_clients` method. This ensures that only valid certificates are used during client initialization.